### PR TITLE
fix: current word is not bounded

### DIFF
--- a/autoload/quickhl/cword.vim
+++ b/autoload/quickhl/cword.vim
@@ -13,7 +13,7 @@ endfunction "}}}
 
 function! s:cword.set() "{{{
   let pattern = quickhl#escape(expand('<cword>'))
-  exe "2match QuickhlCword /". pattern . "/"
+  exe "2match QuickhlCword /\\\<". pattern . "\\\>/"
 endfunction "}}}
 
 function! s:cword.clear() "{{{


### PR DESCRIPTION
In the original code, the `<cword>` is not bounded when automatic cword highlighting is enabled. My fix makes it bounded. IMO, it makes more sense as when navigating the code, we are only interested in the usage of the **whole word**.