### PR TITLE
Fix quickhl-manual-this-whole-word and Add quickhl-manual-clear

### DIFF
--- a/autoload/quickhl/manual.vim
+++ b/autoload/quickhl/manual.vim
@@ -176,6 +176,23 @@ function! quickhl#manual#this_whole_word(mode) "{{{
   call quickhl#manual#add_or_del('\<'. quickhl#escape(pattern).'\>', 1)
 endfunction "}}}
 
+function! quickhl#manual#clear_this(mode) " {{{
+  if !s:manual.enabled | call quickhl#manual#enable() | endif
+  let pattern =
+        \ a:mode == 'n' ? expand('<cword>') :
+        \ a:mode == 'v' ? quickhl#get_selected_text() :
+        \ ""
+  if pattern == '' | return | endif
+  let l:pattern_et = quickhl#escape(pattern)
+  let l:pattern_ew = '\<' . quickhl#escape(pattern) . '\>'
+  if s:manual.index_of(l:pattern_et) != -1
+    call s:manual.del(l:pattern_et, 1)
+  elseif s:manual.index_of(l:pattern_ew) != -1
+    call s:manual.del(l:pattern_ew, 1)
+  endif
+  call quickhl#manual#refresh()
+endfunction " }}}
+
 function! quickhl#manual#add_or_del(pattern, escaped) "{{{
   if !s:manual.enabled | call quickhl#manual#enable() | endif
 

--- a/autoload/quickhl/manual.vim
+++ b/autoload/quickhl/manual.vim
@@ -173,12 +173,13 @@ function! quickhl#manual#this_whole_word(mode) "{{{
         \ a:mode == 'v' ? quickhl#get_selected_text() :
         \ ""
   if pattern == '' | return | endif
-  call quickhl#manual#add_or_del('\<'.pattern.'\>', 1)
+  call quickhl#manual#add_or_del('\<'. quickhl#escape(pattern).'\>', 1)
 endfunction "}}}
 
 function! quickhl#manual#add_or_del(pattern, escaped) "{{{
   if !s:manual.enabled | call quickhl#manual#enable() | endif
-  if s:manual.index_of(quickhl#escape(a:pattern)) == -1
+
+  if s:manual.index_of(a:escaped?a:pattern:quickhl#escape(a:pattern)) == -1
     call s:manual.add(a:pattern, a:escaped)
   else
     call s:manual.del(a:pattern, a:escaped)

--- a/plugin/quickhl.vim
+++ b/plugin/quickhl.vim
@@ -68,6 +68,8 @@ nnoremap <silent> <Plug>(quickhl-manual-this-whole-word) :call quickhl#manual#th
 vnoremap <silent> <Plug>(quickhl-manual-this-whole-word) :call quickhl#manual#this_whole_word('v')<CR>
 nnoremap <silent> <Plug>(quickhl-manual-reset)  :call quickhl#manual#reset()<CR>
 vnoremap <silent> <Plug>(quickhl-manual-reset)  :call quickhl#manual#reset()<CR>
+nnoremap <silent> <Plug>(quickhl-manual-clear)  :call quickhl#manual#clear_this('n')<CR>
+vnoremap <silent> <Plug>(quickhl-manual-clear)  :call quickhl#manual#clear_this('v')<CR>
 nnoremap <silent> <Plug>(quickhl-manual-toggle) :call quickhl#manual#lock_toggle()<CR>
 vnoremap <silent> <Plug>(quickhl-manual-toggle) :call quickhl#manual#lock_toggle()<CR>
 


### PR DESCRIPTION
 - #18 Issues:
 'quickhl-manual-this-whole-word' can only add match but not can's toggle match.
  - Add quickhl-manual-clear:
 Add quickhl-manual-clear to clear the highlighted word or whole word under cursor.