### PR TITLE
preserve height of inactive squashed window

### DIFF
--- a/autoload/quickhl.vim
+++ b/autoload/quickhl.vim
@@ -34,17 +34,21 @@ function! quickhl#windo(func, obj) abort "{{{
       return
     endif
   endif
-  let winnum = winnr()
-  let pwinnum = winnr('#')
-  " echo [pwinnum, winnum]
-  " echo PP(a:func)
-  " echo PP(a:obj)
-  noautocmd windo call call(a:func, [], a:obj)
-  
-  if pwinnum !=# 0
-    execute pwinnum . "wincmd w"
+  if exists('*win_execute')
+    call map(range(1, winnr('$')), "win_execute(win_getid(v:val), 'call call(a:func, [], a:obj)')")
+  else
+    let winnum = winnr()
+    let pwinnum = winnr('#')
+    " echo [pwinnum, winnum]
+    " echo PP(a:func)
+    " echo PP(a:obj)
+    noautocmd windo call call(a:func, [], a:obj)
+
+    if pwinnum !=# 0
+      execute pwinnum . "wincmd w"
+    endif
+    execute winnum . "wincmd w"
   endif
-  execute winnum . "wincmd w"
 endfunction "}}}
 
 " vim: foldmethod=marker


### PR DESCRIPTION
**Describe the bug**

The plugin causes the height of an inactive squashed window to be reset to 1.

**To Reproduce**

Write this inside `/tmp/vimrc`:

    " replace with actual path to the vim-quickhl plugin
    "        vvvvvvvvvvvvvvvvvvvvvvvvvv
    set rtp^=~/.vim/plugged/vim-quickhl
    set wmh=0
    sp
    au VimEnter * call timer_start(0, {-> execute('wincmd _')})

Start Vim with this shell command:

    vim -Nu /tmp/vimrc <(echo "foo\nbar\nbaz")

You should have 2 horizontal windows, and the bottom one should be squashed to 0 lines.

Now, while your cursor is on `foo`, execute this Ex command:

    call quickhl#manual#this_whole_word('n')

The word `foo` is correctly highlighted, but the height of the bottom window has been reset from 0 lines to 1 line.

**Expected behavior**

The plugin preserves the height of the inactive squashed window to 0 lines.

**Screenshots**

![gif](https://user-images.githubusercontent.com/8505073/71178355-4fdf4280-226e-11ea-8280-f330e24dba7a.gif)

**Environment**

 - Vim version: 8.2 Included patches: 1-7
 - `vim-quickhl` version: commit ea4d43e3fd9a36cafc9a36b84021e10a31b70a35
 - OS: Ubuntu 16.04.6 LTS
 - Terminal: XTerm(322)

**Additional context**

I think the issue is due to `:windo`:
https://github.com/t9md/vim-quickhl/blob/ea4d43e3fd9a36cafc9a36b84021e10a31b70a35/autoload/quickhl.vim#L42

and is explained at `:h 'wmh`:

> When set to zero, windows may be "squashed" to zero lines (i.e. just a
> status bar) if necessary.  **They will return to at least one line when
> they become active** (since the cursor has to have somewhere to go.)

When `:windo` makes a window temporarily active, the cursor has to be drawn somewhere, and the window's height is reset to 1 line. Unfortunately, `:windo` does not restore the window's height to 0 lines when leaving it.

One solution would be to invoke `win_execute()` which does not suffer from this side-effect.
As a benefit, you would not need to worry about preserving the current window, nor the previous window. IOW, this whole block:

https://github.com/t9md/vim-quickhl/blob/ea4d43e3fd9a36cafc9a36b84021e10a31b70a35/autoload/quickhl.vim#L37-L47

could be replaced with this function call:

    call map(range(1, winnr('$')), "win_execute(win_getid(v:val), 'call call(a:func, [], a:obj)')")

`win_execute()` was only introduced in the Vim patch [`8.1.1418`](https://github.com/vim/vim/releases/tag/v8.1.1418), so to support old Vim versions, you could check the existence of the function:

    if exists('*win_execute')
      call map(range(1, winnr('$')), "win_execute(win_getid(v:val), 'call call(a:func, [], a:obj)')")
    else
      let winnum = winnr()
      let pwinnum = winnr('#')
      " echo [pwinnum, winnum]
      " echo PP(a:func)
      " echo PP(a:obj)
      noautocmd windo call call(a:func, [], a:obj)

      if pwinnum !=# 0
        execute pwinnum . "wincmd w"
      endif
      execute winnum . "wincmd w"
    endif

Credit to [@Houl](https://github.com/vim/vim/issues/5373#issuecomment-567149062) and [@andymass](https://github.com/vim/vim/issues/5373#issuecomment-567311793) for helping me find a way to pass `a:func` and `a:obj` to `call()`.
