### PR TITLE
add new commands QuickhlManualNext, QuickhlManualPrev

### DIFF
--- a/autoload/quickhl/manual.vim
+++ b/autoload/quickhl/manual.vim
@@ -155,6 +155,17 @@ function! s:manual.list() "{{{
   endfor
 endfunction "}}}
 
+function! s:manual.search(flag) "{{{
+  let pattern = ''
+  for color in self.colors
+    if color.pattern != ''
+      let pattern = pattern . '\|' . color.pattern
+    endif
+  endfor
+  " eliminate first '\|'
+  call search(pattern->strpart(2), a:flag)
+endfunction "}}}
+
 function! quickhl#manual#this(mode) "{{{
   if !s:manual.enabled | call quickhl#manual#enable() | endif
   let pattern =
@@ -306,6 +317,22 @@ endfunction "}}}
 
 function! quickhl#manual#init_highlight() "{{{
   call s:manual.init_highlight()
+endfunction "}}}
+
+function! quickhl#manual#next(...) "{{{
+  let flags = ""
+  if a:0 == 1
+    let flags = a:1
+  endif
+  call s:manual.search("" . flags)
+endfunction "}}}
+
+function! quickhl#manual#prev(...) "{{{
+  let flags = ""
+  if a:0 == 1
+    let flags = a:1
+  endif
+  call s:manual.search("b" . flags)
 endfunction "}}}
 
 function! quickhl#manual#this_motion(motion_wise) " {{{

--- a/autoload/quickhl/manual.vim
+++ b/autoload/quickhl/manual.vim
@@ -319,7 +319,7 @@ function! quickhl#manual#init_highlight() "{{{
   call s:manual.init_highlight()
 endfunction "}}}
 
-function! quickhl#manual#next(...) "{{{
+function! quickhl#manual#go_to_next(...) "{{{
   let flags = ""
   if a:0 == 1
     let flags = a:1
@@ -327,7 +327,7 @@ function! quickhl#manual#next(...) "{{{
   call s:manual.search("" . flags)
 endfunction "}}}
 
-function! quickhl#manual#prev(...) "{{{
+function! quickhl#manual#go_to_prev(...) "{{{
   let flags = ""
   if a:0 == 1
     let flags = a:1

--- a/autoload/quickhl/manual.vim
+++ b/autoload/quickhl/manual.vim
@@ -163,7 +163,7 @@ function! s:manual.search(flag) "{{{
     endif
   endfor
   " eliminate first '\|'
-  call search(pattern->strpart(2), a:flag)
+  call search(strpart(pattern, 2), a:flag)
 endfunction "}}}
 
 function! quickhl#manual#this(mode) "{{{

--- a/doc/quickhl.txt
+++ b/doc/quickhl.txt
@@ -50,8 +50,8 @@ n   <Plug>(quickhl-manual-toggle)
 v   <Plug>(quickhl-manual-toggle)
 	  Toggle global lock
 
-n   <Plug>(quickhl-manual-next)
-n   <Plug>(quickhl-manual-prev)
+n   <Plug>(quickhl-manual-go-to-next)
+n   <Plug>(quickhl-manual-go-to-prev)
 	  Jump to next/previous highlight
 
 n   <Plug>(quickhl-cword-toggle)
@@ -88,10 +88,10 @@ COMMANDS						*quickhl-commands*
 *:QuickhlManualLockWindow*	Lock version of current window.
 *:QuickhlManualUnlockWindow*	Unlock current window.
 *:QuickhlManualLockWindowToggle*  Toggle window lock.
-*:QuickhlManualNext* {flags}	Jump to next highlight.
-*:QuickhlManualPrev* {flags}	Jump to previous highlight.
-				{flags} is passed |search()|.
-				see ":help search()"
+*:QuickhlManualGoToNext* {flags}	Jump to next highlight.
+*:QuickhlManualGoToPrev* {flags}	Jump to previous highlight.
+					{flags} is passed |search()|.
+					see ":help search()"
 
 *:QuickhlCwordEnable*	Enable highlighting <cword> (updated on |CursorMoved|).
 *:QuickhlCwordDisable*	Disable.

--- a/doc/quickhl.txt
+++ b/doc/quickhl.txt
@@ -50,6 +50,10 @@ n   <Plug>(quickhl-manual-toggle)
 v   <Plug>(quickhl-manual-toggle)
 	  Toggle global lock
 
+n   <Plug>(quickhl-manual-next)
+n   <Plug>(quickhl-manual-prev)
+	  Jump to next/previous highlight
+
 n   <Plug>(quickhl-cword-toggle)
 n   <Plug>(quickhl-cword-enable)
 n   <Plug>(quickhl-cword-disable)
@@ -84,6 +88,10 @@ COMMANDS						*quickhl-commands*
 *:QuickhlManualLockWindow*	Lock version of current window.
 *:QuickhlManualUnlockWindow*	Unlock current window.
 *:QuickhlManualLockWindowToggle*  Toggle window lock.
+*:QuickhlManualNext* {flags}	Jump to next highlight.
+*:QuickhlManualPrev* {flags}	Jump to previous highlight.
+				{flags} is passed |search()|.
+				see ":help search()"
 
 *:QuickhlCwordEnable*	Enable highlighting <cword> (updated on |CursorMoved|).
 *:QuickhlCwordDisable*	Disable.

--- a/plugin/quickhl.vim
+++ b/plugin/quickhl.vim
@@ -72,8 +72,8 @@ nnoremap <silent> <Plug>(quickhl-manual-clear)  :call quickhl#manual#clear_this(
 vnoremap <silent> <Plug>(quickhl-manual-clear)  :call quickhl#manual#clear_this('v')<CR>
 nnoremap <silent> <Plug>(quickhl-manual-toggle) :call quickhl#manual#lock_toggle()<CR>
 vnoremap <silent> <Plug>(quickhl-manual-toggle) :call quickhl#manual#lock_toggle()<CR>
-nnoremap <silent> <Plug>(quickhl-manual-next)   :call quickhl#manual#next('s')<CR>
-nnoremap <silent> <Plug>(quickhl-manual-prev)   :call quickhl#manual#prev('s')<CR>
+nnoremap <silent> <Plug>(quickhl-manual-go-to-next) :call quickhl#manual#go_to_next('s')<CR>
+nnoremap <silent> <Plug>(quickhl-manual-go-to-prev) :call quickhl#manual#go_to_prev('s')<CR>
 
 nnoremap <silent> <Plug>(quickhl-cword-toggle)  :call quickhl#cword#toggle()<CR>
 nnoremap <silent> <Plug>(quickhl-cword-enable)  :call quickhl#cword#enable()<CR>
@@ -94,8 +94,8 @@ command! -bang -nargs=1 QuickhlManualAdd     :call quickhl#manual#add(<q-args>,<
 command! -bang -nargs=* QuickhlManualDelete  :call quickhl#manual#del(<q-args>,<bang>0)
 command!                QuickhlManualLock    :call quickhl#manual#lock()
 
-command!       -nargs=? QuickhlManualNext    :call quickhl#manual#next(<f-args>)
-command!       -nargs=? QuickhlManualPrev    :call quickhl#manual#prev(<f-args>)
+command!       -nargs=? QuickhlManualGoToNext :call quickhl#manual#go_to_next(<f-args>)
+command!       -nargs=? QuickhlManualGoToPrev :call quickhl#manual#go_to_prev(<f-args>)
 
 command! QuickhlManualUnlock            :call quickhl#manual#unlock()
 command! QuickhlManualLockToggle        :call quickhl#manual#lock_toggle()

--- a/plugin/quickhl.vim
+++ b/plugin/quickhl.vim
@@ -72,6 +72,8 @@ nnoremap <silent> <Plug>(quickhl-manual-clear)  :call quickhl#manual#clear_this(
 vnoremap <silent> <Plug>(quickhl-manual-clear)  :call quickhl#manual#clear_this('v')<CR>
 nnoremap <silent> <Plug>(quickhl-manual-toggle) :call quickhl#manual#lock_toggle()<CR>
 vnoremap <silent> <Plug>(quickhl-manual-toggle) :call quickhl#manual#lock_toggle()<CR>
+nnoremap <silent> <Plug>(quickhl-manual-next)   :call quickhl#manual#next('s')<CR>
+nnoremap <silent> <Plug>(quickhl-manual-prev)   :call quickhl#manual#prev('s')<CR>
 
 nnoremap <silent> <Plug>(quickhl-cword-toggle)  :call quickhl#cword#toggle()<CR>
 nnoremap <silent> <Plug>(quickhl-cword-enable)  :call quickhl#cword#enable()<CR>
@@ -91,6 +93,9 @@ command!                QuickhlManualColors  :call quickhl#manual#colors()
 command! -bang -nargs=1 QuickhlManualAdd     :call quickhl#manual#add(<q-args>,<bang>0)
 command! -bang -nargs=* QuickhlManualDelete  :call quickhl#manual#del(<q-args>,<bang>0)
 command!                QuickhlManualLock    :call quickhl#manual#lock()
+
+command!       -nargs=? QuickhlManualNext    :call quickhl#manual#next(<f-args>)
+command!       -nargs=? QuickhlManualPrev    :call quickhl#manual#prev(<f-args>)
 
 command! QuickhlManualUnlock            :call quickhl#manual#unlock()
 command! QuickhlManualLockToggle        :call quickhl#manual#lock_toggle()


### PR DESCRIPTION
Thank you for the great plugin.
This PR adds some jump commands.
- `<Plug>(quickhl-manual-next)`
- `<Plug>(quickhl-manual-prev)`
- `QuickhlManualNext`
- `QuickhlManualPrev`

I think these commands will improve the experience when reading large log files.