### PR TITLE
doc: Fix mappings link

### DIFF
--- a/doc/quickhl.txt
+++ b/doc/quickhl.txt
@@ -16,7 +16,7 @@ GitHub : https://github.com/t9md/vim-quickhl
 CONTENTS					*quickhl-contents*
 
 Introduction				    |quickhl-introduction|
-Mapping					    |quickhl-mapping|
+Mapping					    |quickhl-mappings|
 Commands				    |quickhl-commands|
 Variables				    |quickhl-variables|
 Configuration Examples			    |quickhl-examples|


### PR DESCRIPTION
The mappings section is named `quickhl-mappings`
but the link in the TOC uses `quickhl-mapping`.