### PR TITLE
Add option quickhl_exact_match to highlight only exact match words.

### DIFF
--- a/autoload/quickhl/manual.vim
+++ b/autoload/quickhl/manual.vim
@@ -68,7 +68,12 @@ endfunction "}}}
 function! s:manual.set() "{{{
   " call map(copy(self.colors), 'matchadd(v:val.name, v:val.pattern)')
   for color in self.colors
-    call matchadd(color.name, color.pattern, g:quickhl_manual_hl_priority)
+    if len(color.pattern) > 0 && exists('g:quickhl_exact_match')
+        let l:pattern = "\\<" . color.pattern . "\\>"
+    else
+        let l:pattern = color.pattern
+    endif
+    call matchadd(color.name, l:pattern, g:quickhl_manual_hl_priority)
   endfor
 endfunction "}}}
 


### PR DESCRIPTION
quickhlで、ハイライトした単語が"hoge"だった場合、

hoge <-- カラーリングされる
hogefuga <-- "hoge"までカラーリングされる

という動作になりますが、"hoge"に完全一致した場合のみカラーリングしたい場合があります。

そこで、オプション"g:quickhl_exact_match"が設定されていた場合、完全一致部分にカラーリングするように
機能追加したくpull requestを送らせていただきます。